### PR TITLE
Fix typo in Persisten[t]Ets

### DIFF
--- a/lib/persistent_ets.ex
+++ b/lib/persistent_ets.ex
@@ -73,7 +73,7 @@ defmodule PersistentEts do
   """
   @spec new(atom, Path.t, [option]) :: tab
   def new(module, path, opts) do
-    child_spec = {PersistenEts.TableManager, {module, path, opts}}
+    child_spec = {PersistentEts.TableManager, {module, path, opts}}
     {:ok, pid} = DynamicSupervisor.start_child(PersistentEts.Supervisor, child_spec)
     PersistentEts.TableManager.borrow(pid)
   end


### PR DESCRIPTION
To reproduce

```
$ iex
iex> PersistentEts.new(:foo, "table.tab", [:named_table])
```

You should see

```
** (ArgumentError) The module PersistenEts.TableManager was given as a child to a supervisor but it does not exist.
    (elixir) lib/supervisor.ex:629: Supervisor.init_child/1
    (elixir) lib/supervisor.ex:733: Supervisor.child_spec/2
    (elixir) lib/dynamic_supervisor.ex:320: DynamicSupervisor.start_child/2
    (persistent_ets) lib/persistent_ets.ex:77: PersistentEts.new/3
```

Oopses `Persisten[t]Ets`.

After the change

```
$ iex
iex> PersistentEts.new(:foo, "table.tab", [:named_table])
```

The output should look a bit better

```
:foo
```